### PR TITLE
Fix typos in assignment word

### DIFF
--- a/code/operations/query/update.cpp
+++ b/code/operations/query/update.cpp
@@ -4,24 +4,24 @@
 #include "operations/query/condition/and.h"
 
 QORM::Update::Update(const QString &tableName,
-                     const std::list<Assignment> &assignements) :
-    Update(tableName, assignements, {}) {}
+                     const std::list<Assignment> &assignments) :
+    Update(tableName, assignments, {}) {}
 
 QORM::Update::Update(const QString &tableName,
-                     const std::list<Assignment> &assignements,
+                     const std::list<Assignment> &assignments,
                      const Condition &condition) :
-    Update(tableName, assignements, std::list<Condition>({condition})) {}
+    Update(tableName, assignments, std::list<Condition>({condition})) {}
 
 QORM::Update::Update(const QString &tableName,
-                     std::list<Assignment> assignements,
+                     std::list<Assignment> assignments,
                      std::list<Condition> conditions) :
-    TableQuery(tableName), assignements(std::move(assignements)),
+    TableQuery(tableName), assignments(std::move(assignments)),
     conditions(std::move(conditions)) {
-    if (this->assignements.empty()) {
-        throw std::invalid_argument("Update must have at least 1 assignement");
+    if (this->assignments.empty()) {
+        throw std::invalid_argument("Update must have at least one assignment");
     }
 
-    for (const auto &assignement : this->assignements) {
+    for (const auto &assignement : this->assignments) {
         this->addBindable(assignement);
     }
     for (const auto &condition : this->conditions) {
@@ -33,10 +33,10 @@ QORM::Update::Update(const QString &tableName,
 
 auto QORM::Update::generate() const -> QString {
     QString update = "update " + this->getTableName() + " set ";
-    QStringList assignements;
-    for (const auto &assignement : this->assignements) {
-        assignements << assignement.generate();
+    QStringList assignments;
+    for (const auto &assignment : this->assignments) {
+        assignments << assignment.generate();
     }
-    return (update + assignements.join(",") +
+    return (update + assignments.join(",") +
         Condition::generateMultiple(" where ", this->conditions)).simplified();
 }

--- a/code/operations/query/update.h
+++ b/code/operations/query/update.h
@@ -9,7 +9,7 @@
 namespace QORM {
 
 class Update : public TableQuery {
-    const std::list<Assignment> assignements;
+    const std::list<Assignment> assignments;
     const std::list<Condition> conditions;
 
  public:
@@ -18,13 +18,13 @@ class Update : public TableQuery {
            const Condition&);
     Update(const QString &tableName, std::list<Assignment>,
            std::list<Condition>);
-    auto getAssignements() const -> const std::list<Assignment>&;
+    auto getAssignments() const -> const std::list<Assignment>&;
     auto getConditions() const -> const std::list<Condition>&;
     auto generate() const -> QString override;
 };
 
-inline auto Update::getAssignements() const -> const std::list<Assignment>& {
-    return this->assignements;
+inline auto Update::getAssignments() const -> const std::list<Assignment>& {
+    return this->assignments;
 }
 
 inline auto Update::getConditions() const -> const std::list<Condition>& {

--- a/test/operations/query/inserttest.cpp
+++ b/test/operations/query/inserttest.cpp
@@ -18,7 +18,7 @@ void InsertTest::generateDefaultValues() {
                         " default values");
 }
 
-void InsertTest::generateWithAssignements() {
+void InsertTest::generateWithAssignments() {
     // Given
     auto const assignement = QORM::Assignment(DEFAULT_FIELD_NAME, 1);
     auto const insert = QORM::Insert(DEFAULT_TABLE_NAME,

--- a/test/operations/query/inserttest.h
+++ b/test/operations/query/inserttest.h
@@ -11,7 +11,7 @@ class InsertTest : public QObject {
 
  private slots:
     static void generateDefaultValues();
-    static void generateWithAssignements();
+    static void generateWithAssignments();
 };
 
 #endif  // TEST_OPERATIONS_QUERY_INSERTTEST_H_

--- a/test/operations/query/updatetest.cpp
+++ b/test/operations/query/updatetest.cpp
@@ -8,7 +8,7 @@
 const QString UpdateTest::DEFAULT_TABLE_NAME = "table_name";
 const QString UpdateTest::DEFAULT_FIELD_NAME = "field_name";
 
-void UpdateTest::withoutAssignementsShouldFail() {
+void UpdateTest::withoutAssignmentsShouldFail() {
     // When / Then
     QVERIFY_EXCEPTION_THROWN(QORM::Update(DEFAULT_TABLE_NAME, {}, {}),
                              std::invalid_argument);

--- a/test/operations/query/updatetest.h
+++ b/test/operations/query/updatetest.h
@@ -10,7 +10,7 @@ class UpdateTest : public QObject {
     static const QString DEFAULT_FIELD_NAME;
 
  private slots:
-    static void withoutAssignementsShouldFail();
+    static void withoutAssignmentsShouldFail();
     static void generateWithoutConditions();
     static void generateWithConditions();
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved consistency and clarity in naming by correcting the spelling of "assignments" across various classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->